### PR TITLE
Ignore convergence warning on predict_x_event function

### DIFF
--- a/functions.py
+++ b/functions.py
@@ -4,6 +4,8 @@ import numpy as np
 from sklearn.linear_model import LogisticRegression
 from sklearn.metrics import roc_curve, roc_auc_score
 from sklearn.model_selection import GridSearchCV
+from sklearn.utils._testing import ignore_warnings
+from sklearn.exceptions import ConvergenceWarning
 
 def create_save_features(dname):
 
@@ -277,6 +279,7 @@ def train_mode(dname, filters, fname):
     
     return 0
 
+@ignore_warnings(category=ConvergenceWarning)
 def predict_mode(dname, filters, fname, fname_out):
     '''
     Make predictions for all time-series in dname using the filters and the

--- a/functions.py
+++ b/functions.py
@@ -279,7 +279,6 @@ def train_mode(dname, filters, fname):
     
     return 0
 
-@ignore_warnings(category=ConvergenceWarning)
 def predict_mode(dname, filters, fname, fname_out):
     '''
     Make predictions for all time-series in dname using the filters and the
@@ -412,6 +411,7 @@ def train_minotaur(dataset_t, dataset_X, dataset_y):
 
     return B_coef, B_bias, res_t, res_y_hat, res_auc, res_fpr, res_tpr
    
+@ignore_warnings(category=ConvergenceWarning)
 def predict_x_event(dataset_t, dataset_X, dataset_y, B_coef, B_bias, fname):
     '''
     Performs prediction for the data inside the dataset structure and


### PR DESCRIPTION
This only ignores the convergence warning when evaluating the model. The predict_mode function calls the predict_x_event function which evaluates the model, so only there the convergence warnings need to be ignored.

The warnings should work as usual anywhere else (when training).